### PR TITLE
Relabel projects to instances

### DIFF
--- a/src/ui/components/projectSelection.js
+++ b/src/ui/components/projectSelection.js
@@ -33,20 +33,20 @@ export function ProjectSelectionWidget () {
         if (project) {
             widget.find('span').text(project.name)
         } else if (projects.length === 0) {
-            widget.find('span').html('<i>no projects available</i>')
+            widget.find('span').html('<i>no instances available</i>')
         } else {
-            widget.find('span').html('<i>select project</i>')
+            widget.find('span').html('<i>select instance</i>')
         }
         currentProject = id
         if (project) {
             const projectInfo = await api.getProject(currentProject)
             if (projectInfo.code) {
-                events.emit('project', null)
+                events.emit('instance', null)
             } else {
-                events.emit('project', projectInfo)
+                events.emit('instance', projectInfo)
             }
         } else {
-            events.emit('project', null)
+            events.emit('instance', null)
         }
     }
     events.on('connection-state', async function (state) {
@@ -83,7 +83,7 @@ export function ProjectSelectionWidget () {
                 button.find('.fa-caret-down').hide()
             }
         } catch (err) {
-            console.warn('Failed to load project list:', err.toString())
+            console.warn('Failed to load instance list:', err.toString())
         }
     })
     return widget

--- a/src/ui/views/mainPane.js
+++ b/src/ui/views/mainPane.js
@@ -3,9 +3,9 @@ import $ from 'jquery'
 import { snapshotSection } from './snapshotSection'
 import * as events from '../events'
 
-events.on('project', async (_project) => {
-    $('.ff-nr-tools-pane-stack').toggle(!!_project)
-    $('.ff-nr-tools-pane-placeholder').toggle(!_project)
+events.on('instance', async (_instance) => {
+    $('.ff-nr-tools-pane-stack').toggle(!!_instance)
+    $('.ff-nr-tools-pane-placeholder').toggle(!_instance)
 })
 
 const mainPane = {
@@ -15,7 +15,7 @@ const mainPane = {
         const pane = $(`
 <div class="ff-nr-tools-pane">
     <div class="ff-nr-tools-pane ff-nr-tools-pane-placeholder ff-nr-tools-pane-centered">
-        <i>Select a Team and Project</i>
+        <i>Select a Team and Instance</i>
     </div>
     <div class="ff-nr-tools-pane-stack"></div>
 </div>`)

--- a/src/ui/views/snapshotSection.js
+++ b/src/ui/views/snapshotSection.js
@@ -5,10 +5,10 @@ import { SnapshotListItem } from '../components/snapshotListItem'
 import * as events from '../events'
 
 let team = null
-let project = null
-events.on('project', async (_project) => {
-    project = _project
-    if (project) {
+let instance = null
+events.on('instance', async (_instance) => {
+    instance = _instance
+    if (instance) {
         refreshSnapshots()
     }
 })
@@ -20,8 +20,8 @@ let snapshotList = null
 
 async function refreshSnapshots () {
     snapshotList.editableList('empty')
-    if (project) {
-        const snapshots = await api.getProjectSnapshots(project.id)
+    if (instance) {
+        const snapshots = await api.getProjectSnapshots(instance.id)
         if (snapshots.snapshots && snapshots.snapshots.length > 0) {
             snapshotList.editableList('addItems', snapshots.snapshots || [])
             return
@@ -73,7 +73,7 @@ function showSnapshotDialog () {
         snapshotDialog = $('<div id="ff-nr-tools-snapshot-dialog"><form class="ff-nr-tools-form dialog-form form-horizontal"></form></div>')
             .appendTo('#red-ui-editor')
             .dialog({
-                title: 'Create Project Snapshot',
+                title: 'Create Snapshot',
                 modal: true,
                 width: 400,
                 autoOpen: false,
@@ -105,7 +105,7 @@ function showSnapshotDialog () {
                                     modules
                                 }
                             }
-                            api.createProjectSnapshot(project.id, options).then(() => {
+                            api.createProjectSnapshot(instance.id, options).then(() => {
                                 refreshSnapshots()
                             }).catch(err => {
                                 console.log(err)
@@ -127,9 +127,9 @@ function showSnapshotDialog () {
     const dialogContainer = snapshotDialog.children('.dialog-form').empty()
     const form = $(`
 <div class="form-row">
-    <label>Project</label>
+    <label>Instance</label>
     <div class="uneditable-input" style="width: 100%; color: var(--red-ui-form-text-color);">
-        <img width="18px" id="ff-nr-tools-snapshot-team-avatar"> <span id="ff-nr-tools-snapshot-project-name"></span>
+        <img width="18px" id="ff-nr-tools-snapshot-team-avatar"> <span id="ff-nr-tools-snapshot-instance-name"></span>
     </div>
 </div>
 <div class="form-row">
@@ -163,9 +163,9 @@ function showSnapshotDialog () {
         }
     })
     form.find('#ff-nr-tools-snapshot-module-list').editableList('addItems', getCurrentModuleList())
-    if (team && project) {
+    if (team && instance) {
         form.find('#ff-nr-tools-snapshot-team-avatar').attr('src', team.avatar)
-        form.find('#ff-nr-tools-snapshot-project-name').text(project.name)
+        form.find('#ff-nr-tools-snapshot-instance-name').text(instance.name)
     }
     snapshotDialog.dialog('open')
 }


### PR DESCRIPTION
Fixes #8 

This replaces the 'project' terminology for 'instance' - in line with the 1.5 release.

Internal components still use Project terminology, but they can be refactored as needed in the future.